### PR TITLE
Fix nanos cast on macOS 10.14.6

### DIFF
--- a/src/Time.cpp
+++ b/src/Time.cpp
@@ -79,7 +79,8 @@ Time::Time(std::string const& s) {
     pnt_ = Clock::from_time_t(seconds);
     if (!fraction.empty()) {
         fraction.resize(9, '0');
-        pnt_ += nanoseconds{std::stol(fraction)};
+        auto const nanos = nanoseconds{std::stol(fraction)};
+        pnt_ += std::chrono::duration_cast<microseconds>(nanos);
     }
 }
 


### PR DESCRIPTION
Otherwise it seems to fail on my machine.

`no viable overloaded '+='`
```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/chrono:1372:73: note: candidate function not viable: no known conversion from 'duration<[...], ratio<[...], 1000000000>>' to 'const duration<[...], ratio<[...], 1000000>>' for 1st argument
    _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_AFTER_CXX14 time_point& operator+=(const duration& __d) {__d_ += __d; return *this;}
```